### PR TITLE
Update LevelItem.cpp greater than and equal to

### DIFF
--- a/src/LevelItem.cpp
+++ b/src/LevelItem.cpp
@@ -26,7 +26,7 @@ public:
             return false;
         }
 
-        if (p->getLevel() == max_lvl)
+        if (p->getLevel() >= max_lvl)
         {
             ChatHandler(p->GetSession()).PSendSysMessage("You are already Max Level");
             return false;


### PR DESCRIPTION
currently if you set the max level to say 60 for example and you are level 61 then the token can be used, by setting greater than or equal to the item cannot be used past max level set in the conf.